### PR TITLE
feat: 메일 인증 시스템 구현

### DIFF
--- a/src/main/java/com/github/teamreflog/reflogserver/mail/application/MailService.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/application/MailService.java
@@ -1,0 +1,24 @@
+package com.github.teamreflog.reflogserver.mail.application;
+
+import com.github.teamreflog.reflogserver.mail.application.dto.MailSendRequest;
+import com.github.teamreflog.reflogserver.mail.application.dto.MailSendResponse;
+import com.github.teamreflog.reflogserver.mail.domain.MailAuthCodeGenerator;
+import com.github.teamreflog.reflogserver.mail.domain.MailAuthData;
+import com.github.teamreflog.reflogserver.mail.domain.MailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final MailAuthCodeGenerator mailAuthCodeGenerator;
+    private final MailRepository mailRepository;
+
+    public MailSendResponse sendAuthMail(final MailSendRequest request) {
+        final MailAuthData data =
+                MailAuthData.of(request.email(), mailAuthCodeGenerator.generateCode());
+
+        return new MailSendResponse(mailRepository.save(data));
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/application/MailService.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/application/MailService.java
@@ -5,6 +5,7 @@ import com.github.teamreflog.reflogserver.mail.application.dto.MailSendResponse;
 import com.github.teamreflog.reflogserver.mail.domain.MailAuthCodeGenerator;
 import com.github.teamreflog.reflogserver.mail.domain.MailAuthData;
 import com.github.teamreflog.reflogserver.mail.domain.MailRepository;
+import com.github.teamreflog.reflogserver.mail.domain.MailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,11 +14,14 @@ import org.springframework.stereotype.Service;
 public class MailService {
 
     private final MailAuthCodeGenerator mailAuthCodeGenerator;
+    private final MailSender mailSender;
     private final MailRepository mailRepository;
 
     public MailSendResponse sendAuthMail(final MailSendRequest request) {
         final MailAuthData data =
                 MailAuthData.of(request.email(), mailAuthCodeGenerator.generateCode());
+
+        mailSender.sendAuthMail(data.getEmail(), data.getCode());
 
         return new MailSendResponse(mailRepository.save(data));
     }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/application/MailService.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/application/MailService.java
@@ -2,6 +2,7 @@ package com.github.teamreflog.reflogserver.mail.application;
 
 import com.github.teamreflog.reflogserver.mail.application.dto.MailSendRequest;
 import com.github.teamreflog.reflogserver.mail.application.dto.MailSendResponse;
+import com.github.teamreflog.reflogserver.mail.application.dto.MailVerifyRequest;
 import com.github.teamreflog.reflogserver.mail.domain.MailAuthCodeGenerator;
 import com.github.teamreflog.reflogserver.mail.domain.MailAuthData;
 import com.github.teamreflog.reflogserver.mail.domain.MailRepository;
@@ -24,5 +25,11 @@ public class MailService {
         mailSender.sendAuthMail(data.getEmail(), data.getCode());
 
         return new MailSendResponse(mailRepository.save(data));
+    }
+
+    public void verifyAuthMail(final MailVerifyRequest request) {
+        final MailAuthData authData = mailRepository.getById(request.id());
+
+        mailRepository.update(request.id(), authData.verify(request.code()));
     }
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailSendRequest.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailSendRequest.java
@@ -1,0 +1,3 @@
+package com.github.teamreflog.reflogserver.mail.application.dto;
+
+public record MailSendRequest(String email) {}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailSendResponse.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailSendResponse.java
@@ -1,3 +1,3 @@
 package com.github.teamreflog.reflogserver.mail.application.dto;
 
-public record MailSendResponse(String authMailId) {}
+public record MailSendResponse(String id) {}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailSendResponse.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailSendResponse.java
@@ -1,0 +1,3 @@
+package com.github.teamreflog.reflogserver.mail.application.dto;
+
+public record MailSendResponse(String authMailId) {}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailVerifyRequest.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailVerifyRequest.java
@@ -1,0 +1,3 @@
+package com.github.teamreflog.reflogserver.mail.application.dto;
+
+public record MailVerifyRequest(String authMailId, Integer authMailNumber) {}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailVerifyRequest.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/application/dto/MailVerifyRequest.java
@@ -1,3 +1,3 @@
 package com.github.teamreflog.reflogserver.mail.application.dto;
 
-public record MailVerifyRequest(String authMailId, Integer authMailNumber) {}
+public record MailVerifyRequest(String id, Integer code) {}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthCodeGenerator.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthCodeGenerator.java
@@ -1,0 +1,6 @@
+package com.github.teamreflog.reflogserver.mail.domain;
+
+public interface MailAuthCodeGenerator {
+
+    Integer generateCode();
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthData.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthData.java
@@ -13,8 +13,8 @@ public class MailAuthData {
     @Getter private final Integer code;
     private final Boolean isVerified;
 
-    public static MailAuthData of(@NonNull final String mail, @NonNull final Integer number) {
-        return new MailAuthData(mail, number, false);
+    public static MailAuthData of(@NonNull final String mail, @NonNull final Integer code) {
+        return new MailAuthData(mail, code, false);
     }
 
     public MailAuthData verify(final Integer code) {

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthData.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthData.java
@@ -2,13 +2,14 @@ package com.github.teamreflog.reflogserver.mail.domain;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NonNull;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MailAuthData {
 
-    private final String email;
-    private final Integer code;
+    @Getter private final String email;
+    @Getter private final Integer code;
     private final Boolean isVerified;
 
     public static MailAuthData of(@NonNull final String mail, @NonNull final Integer number) {

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthData.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthData.java
@@ -1,0 +1,17 @@
+package com.github.teamreflog.reflogserver.mail.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MailAuthData {
+
+    private final String email;
+    private final Integer code;
+    private final Boolean isVerified;
+
+    public static MailAuthData of(@NonNull final String mail, @NonNull final Integer number) {
+        return new MailAuthData(mail, number, false);
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthData.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthData.java
@@ -1,5 +1,6 @@
 package com.github.teamreflog.reflogserver.mail.domain;
 
+import com.github.teamreflog.reflogserver.mail.exception.MailAuthCodeNotMatchedException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,5 +15,17 @@ public class MailAuthData {
 
     public static MailAuthData of(@NonNull final String mail, @NonNull final Integer number) {
         return new MailAuthData(mail, number, false);
+    }
+
+    public MailAuthData verify(final Integer code) {
+        if (!isMatchedCode(code)) {
+            throw new MailAuthCodeNotMatchedException();
+        }
+
+        return new MailAuthData(email, code, true);
+    }
+
+    private boolean isMatchedCode(final Integer code) {
+        return this.code.equals(code);
     }
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailRepository.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailRepository.java
@@ -2,9 +2,9 @@ package com.github.teamreflog.reflogserver.mail.domain;
 
 public interface MailRepository {
 
-    String save(final MailAuthData mailAuthData);
+    String save(MailAuthData mailAuthData);
 
-    MailAuthData getById(final String authMailId);
+    MailAuthData getById(String id);
 
     void update(String id, MailAuthData newData);
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailRepository.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailRepository.java
@@ -1,0 +1,8 @@
+package com.github.teamreflog.reflogserver.mail.domain;
+
+public interface MailRepository {
+
+    String save(final MailAuthData mailAuthData);
+
+    MailAuthData getById(final String authMailId);
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailRepository.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailRepository.java
@@ -5,4 +5,6 @@ public interface MailRepository {
     String save(final MailAuthData mailAuthData);
 
     MailAuthData getById(final String authMailId);
+
+    void update(String id, MailAuthData newData);
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailSender.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/domain/MailSender.java
@@ -1,0 +1,6 @@
+package com.github.teamreflog.reflogserver.mail.domain;
+
+public interface MailSender {
+
+    void sendAuthMail(final String mail, final Integer code);
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/exception/MailAuthCodeNotMatchedException.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/exception/MailAuthCodeNotMatchedException.java
@@ -5,6 +5,6 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 public class MailAuthCodeNotMatchedException extends MailException {
 
     public MailAuthCodeNotMatchedException() {
-        super(BAD_REQUEST, "인증 코드가 일치하지 않습니다.");
+        super(BAD_REQUEST, "인증 번호가 일치하지 않습니다.");
     }
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/exception/MailAuthCodeNotMatchedException.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/exception/MailAuthCodeNotMatchedException.java
@@ -1,0 +1,10 @@
+package com.github.teamreflog.reflogserver.mail.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class MailAuthCodeNotMatchedException extends MailException {
+
+    public MailAuthCodeNotMatchedException() {
+        super(BAD_REQUEST, "인증 코드가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/exception/MailException.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/exception/MailException.java
@@ -1,0 +1,16 @@
+package com.github.teamreflog.reflogserver.mail.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class MailException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    protected MailException(final HttpStatus status, final String message) {
+        super(message);
+
+        this.status = status;
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/exception/MailExceptionHandler.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/exception/MailExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.github.teamreflog.reflogserver.mail.exception;
+
+import com.github.teamreflog.reflogserver.common.exception.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MailExceptionHandler {
+
+    @ExceptionHandler(MailException.class)
+    public ResponseEntity<ErrorResponse> handleMailException(final MailException e) {
+
+        return new ResponseEntity<>(new ErrorResponse(e.getMessage()), e.getStatus());
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/GmailSender.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/GmailSender.java
@@ -1,0 +1,13 @@
+package com.github.teamreflog.reflogserver.mail.infrastructure;
+
+import com.github.teamreflog.reflogserver.mail.domain.MailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GmailSender implements MailSender {
+
+    @Override
+    public void sendAuthMail(final String mail, final Integer code) {
+        // TODO: Gmail SMTP 서버를 이용해 메일을 보내는 로직을 구현
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/MailRepositoryImpl.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/MailRepositoryImpl.java
@@ -30,4 +30,9 @@ public class MailRepositoryImpl implements MailRepository {
 
         return mailAuthDataById.get(id);
     }
+
+    @Override
+    public void update(final String id, final MailAuthData newData) {
+        mailAuthDataById.put(id, newData);
+    }
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/MailRepositoryImpl.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/MailRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.github.teamreflog.reflogserver.mail.infrastructure;
+
+import com.github.teamreflog.reflogserver.common.exception.ReflogIllegalArgumentException;
+import com.github.teamreflog.reflogserver.mail.domain.MailAuthData;
+import com.github.teamreflog.reflogserver.mail.domain.MailRepository;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MailRepositoryImpl implements MailRepository {
+
+    // TODO: 캐시로 변경
+    private final Map<String, MailAuthData> mailAuthDataById = new ConcurrentHashMap<>();
+
+    @Override
+    public String save(final MailAuthData mailAuthData) {
+        final String id = UUID.randomUUID().toString();
+        mailAuthDataById.put(id, mailAuthData);
+
+        return id;
+    }
+
+    @Override
+    public MailAuthData getById(final String id) {
+        if (!mailAuthDataById.containsKey(id)) {
+            throw new ReflogIllegalArgumentException();
+        }
+
+        return mailAuthDataById.get(id);
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/RandomSixDigitCodeGenerator.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/RandomSixDigitCodeGenerator.java
@@ -1,0 +1,14 @@
+package com.github.teamreflog.reflogserver.mail.infrastructure;
+
+import com.github.teamreflog.reflogserver.mail.domain.MailAuthCodeGenerator;
+import java.util.concurrent.ThreadLocalRandom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RandomSixDigitCodeGenerator implements MailAuthCodeGenerator {
+
+    @Override
+    public Integer generateCode() {
+        return ThreadLocalRandom.current().nextInt(100000, 1000000);
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/RandomSixDigitCodeGenerator.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/infrastructure/RandomSixDigitCodeGenerator.java
@@ -1,14 +1,16 @@
 package com.github.teamreflog.reflogserver.mail.infrastructure;
 
 import com.github.teamreflog.reflogserver.mail.domain.MailAuthCodeGenerator;
-import java.util.concurrent.ThreadLocalRandom;
+import java.security.SecureRandom;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RandomSixDigitCodeGenerator implements MailAuthCodeGenerator {
 
+    private final SecureRandom secureRandom = new SecureRandom();
+
     @Override
     public Integer generateCode() {
-        return ThreadLocalRandom.current().nextInt(100000, 1000000);
+        return secureRandom.nextInt(100000, 1000000);
     }
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/ui/MailController.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/ui/MailController.java
@@ -1,6 +1,9 @@
 package com.github.teamreflog.reflogserver.mail.ui;
 
 import com.github.teamreflog.reflogserver.mail.application.dto.MailSendRequest;
+import com.github.teamreflog.reflogserver.mail.application.dto.MailSendResponse;
+import com.github.teamreflog.reflogserver.mail.application.dto.MailVerifyRequest;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,7 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class MailController {
 
     @PostMapping("/send")
-    public ResponseEntity<Void> sendAuthMail(@RequestBody final MailSendRequest request) {
+    public MailSendResponse sendAuthMail(@RequestBody final MailSendRequest request) {
+
+        return new MailSendResponse(UUID.randomUUID().toString());
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<Void> verifyAuthMail(@RequestBody final MailVerifyRequest request) {
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/ui/MailController.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/ui/MailController.java
@@ -5,7 +5,6 @@ import com.github.teamreflog.reflogserver.mail.application.dto.MailSendRequest;
 import com.github.teamreflog.reflogserver.mail.application.dto.MailSendResponse;
 import com.github.teamreflog.reflogserver.mail.application.dto.MailVerifyRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,8 +23,7 @@ public class MailController {
     }
 
     @PostMapping("/verify")
-    public ResponseEntity<Void> verifyAuthMail(@RequestBody final MailVerifyRequest request) {
-
-        return ResponseEntity.ok().build();
+    public void verifyAuthMail(@RequestBody final MailVerifyRequest request) {
+        mailService.verifyAuthMail(request);
     }
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/ui/MailController.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/ui/MailController.java
@@ -1,0 +1,19 @@
+package com.github.teamreflog.reflogserver.mail.ui;
+
+import com.github.teamreflog.reflogserver.mail.application.dto.MailSendRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/mails")
+public class MailController {
+
+    @PostMapping("/send")
+    public ResponseEntity<Void> sendAuthMail(@RequestBody final MailSendRequest request) {
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/mail/ui/MailController.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/mail/ui/MailController.java
@@ -1,9 +1,10 @@
 package com.github.teamreflog.reflogserver.mail.ui;
 
+import com.github.teamreflog.reflogserver.mail.application.MailService;
 import com.github.teamreflog.reflogserver.mail.application.dto.MailSendRequest;
 import com.github.teamreflog.reflogserver.mail.application.dto.MailSendResponse;
 import com.github.teamreflog.reflogserver.mail.application.dto.MailVerifyRequest;
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,12 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/mails")
+@RequiredArgsConstructor
 public class MailController {
+
+    private final MailService mailService;
 
     @PostMapping("/send")
     public MailSendResponse sendAuthMail(@RequestBody final MailSendRequest request) {
-
-        return new MailSendResponse(UUID.randomUUID().toString());
+        return mailService.sendAuthMail(request);
     }
 
     @PostMapping("/verify")

--- a/src/test/java/com/github/teamreflog/reflogserver/acceptance/MailAcceptanceTest.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/acceptance/MailAcceptanceTest.java
@@ -14,8 +14,36 @@ public class MailAcceptanceTest extends AcceptanceTest {
     @DisplayName("인증 메일을 보낼 때")
     class WhenSendAuthMail {
 
+        String authMailId;
+
         @BeforeEach
         void setUp() {
+            authMailId =
+                    RestAssured.given()
+                            .log()
+                            .all()
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .body(
+                                    """
+                                    {
+                                        "email": "reflog@email.com"
+                                    }
+                                    """)
+                            .when()
+                            .post("/mails/send")
+                            .then()
+                            .log()
+                            .all()
+                            .statusCode(200)
+                            .extract()
+                            .body()
+                            .jsonPath()
+                            .getString("authMailId");
+        }
+
+        @Test
+        @DisplayName("인증 번호를 검증한다.")
+        void verifyAuthNumber() {
             RestAssured.given()
                     .log()
                     .all()
@@ -23,29 +51,17 @@ public class MailAcceptanceTest extends AcceptanceTest {
                     .body(
                             """
                             {
-                                "email": "reflog@email.com"
+                                "authMailId": "%s",
+                                "authNumber": 240114
                             }
-                            """)
+                            """
+                                    .formatted(authMailId))
                     .when()
-                    .post("/mails/send")
+                    .post("/mails/verify")
                     .then()
                     .log()
                     .all()
                     .statusCode(200);
-        }
-
-        @Test
-        @DisplayName("인증 번호를 검증한다.")
-        void verifyAuthNumber() {
-            //            RestAssured.given()
-            //                    .log()
-            //                    .all()
-            //                    .when()
-            //                    .get("/mails/verify")
-            //                    .then()
-            //                    .log()
-            //                    .all()
-            //                    .statusCode(200);
         }
     }
 }

--- a/src/test/java/com/github/teamreflog/reflogserver/acceptance/MailAcceptanceTest.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/acceptance/MailAcceptanceTest.java
@@ -25,10 +25,10 @@ public class MailAcceptanceTest extends AcceptanceTest {
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .body(
                                     """
-                                    {
-                                        "email": "reflog@email.com"
-                                    }
-                                    """)
+                                            {
+                                                "email": "reflog@email.com"
+                                            }
+                                            """)
                             .when()
                             .post("/mails/send")
                             .then()
@@ -38,7 +38,7 @@ public class MailAcceptanceTest extends AcceptanceTest {
                             .extract()
                             .body()
                             .jsonPath()
-                            .getString("authMailId");
+                            .getString("id");
         }
 
         @Test
@@ -50,11 +50,11 @@ public class MailAcceptanceTest extends AcceptanceTest {
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .body(
                             """
-                            {
-                                "authMailId": "%s",
-                                "authNumber": 240114
-                            }
-                            """
+                                    {
+                                        "id": "%s",
+                                        "code": 240114
+                                    }
+                                    """
                                     .formatted(authMailId))
                     .when()
                     .post("/mails/verify")

--- a/src/test/java/com/github/teamreflog/reflogserver/acceptance/MailAcceptanceTest.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/acceptance/MailAcceptanceTest.java
@@ -1,0 +1,51 @@
+package com.github.teamreflog.reflogserver.acceptance;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+@DisplayName("인수 테스트: 메일")
+public class MailAcceptanceTest extends AcceptanceTest {
+
+    @Nested
+    @DisplayName("인증 메일을 보낼 때")
+    class WhenSendAuthMail {
+
+        @BeforeEach
+        void setUp() {
+            RestAssured.given()
+                    .log()
+                    .all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(
+                            """
+                            {
+                                "email": "reflog@email.com"
+                            }
+                            """)
+                    .when()
+                    .post("/mails/send")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(200);
+        }
+
+        @Test
+        @DisplayName("인증 번호를 검증한다.")
+        void verifyAuthNumber() {
+            //            RestAssured.given()
+            //                    .log()
+            //                    .all()
+            //                    .when()
+            //                    .get("/mails/verify")
+            //                    .then()
+            //                    .log()
+            //                    .all()
+            //                    .statusCode(200);
+        }
+    }
+}

--- a/src/test/java/com/github/teamreflog/reflogserver/acceptance/fake/FixedMailAuthCodeGenerator.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/acceptance/fake/FixedMailAuthCodeGenerator.java
@@ -1,0 +1,15 @@
+package com.github.teamreflog.reflogserver.acceptance.fake;
+
+import com.github.teamreflog.reflogserver.mail.domain.MailAuthCodeGenerator;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Component
+public class FixedMailAuthCodeGenerator implements MailAuthCodeGenerator {
+
+    @Override
+    public Integer generateCode() {
+        return 240114;
+    }
+}

--- a/src/test/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthDataTest.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/mail/domain/MailAuthDataTest.java
@@ -1,0 +1,36 @@
+package com.github.teamreflog.reflogserver.mail.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.github.teamreflog.reflogserver.mail.exception.MailAuthCodeNotMatchedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("단위 테스트: MailAuthData")
+class MailAuthDataTest {
+
+    MailAuthData data;
+
+    @BeforeEach
+    void setUp() {
+        data = MailAuthData.of("reflog@email.com", 240114);
+    }
+
+    @Test
+    @DisplayName("인증 번호를 검증한다.")
+    void isMatchedCode() {
+        /* given */
+        final Integer correctCode = 240114;
+        final Integer incorrectCode = 240115;
+
+        /* when & then */
+        assertAll(
+                () -> assertThatCode(() -> data.verify(correctCode)).doesNotThrowAnyException(),
+                () ->
+                        assertThatCode(() -> data.verify(incorrectCode))
+                                .isInstanceOf(MailAuthCodeNotMatchedException.class)
+                                .hasMessage("인증 번호가 일치하지 않습니다."));
+    }
+}

--- a/src/test/java/com/github/teamreflog/reflogserver/mail/infrastructure/MailRepositoryImplTest.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/mail/infrastructure/MailRepositoryImplTest.java
@@ -1,0 +1,52 @@
+package com.github.teamreflog.reflogserver.mail.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.github.teamreflog.reflogserver.common.exception.ReflogIllegalArgumentException;
+import com.github.teamreflog.reflogserver.mail.domain.MailAuthData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("단위 테스트: MailRepositoryImpl")
+class MailRepositoryImplTest {
+
+    MailRepositoryImpl mailRepositoryImpl;
+
+    @BeforeEach
+    void setUp() {
+        mailRepositoryImpl = new MailRepositoryImpl();
+    }
+
+    @Nested
+    @DisplayName("메일 인증 정보를 저장할 때")
+    class WhenSaveData {
+
+        String id;
+
+        @BeforeEach
+        void setUp() {
+            /* given */
+            final MailAuthData data = MailAuthData.of("reflog@email.com", 240114);
+
+            /* when */
+            id = mailRepositoryImpl.save(data);
+
+            /* then */
+            assertThat(id).isNotNull();
+        }
+
+        @Test
+        @DisplayName("식별자에 해당하는 메일 인증 정보가 없으면 예외가 발생한다.")
+        void throwExceptionWhenNotExist() {
+            /* given */
+            final String notExistId = id + "💩";
+
+            /* when & then */
+            assertThatCode(() -> mailRepositoryImpl.getById(notExistId))
+                    .isInstanceOf(ReflogIllegalArgumentException.class);
+        }
+    }
+}

--- a/src/test/java/com/github/teamreflog/reflogserver/mail/infrastructure/RandomSixDigitCodeGeneratorTest.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/mail/infrastructure/RandomSixDigitCodeGeneratorTest.java
@@ -1,0 +1,28 @@
+package com.github.teamreflog.reflogserver.mail.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("단위 테스트: RandomSixDigitCodeGenerator")
+class RandomSixDigitCodeGeneratorTest {
+
+    RandomSixDigitCodeGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        generator = new RandomSixDigitCodeGenerator();
+    }
+
+    @Test
+    @DisplayName("6자리 인증 코드를 생성한다.")
+    void generateSixDigitCode() {
+        /* when */
+        final Integer code = generator.generateCode();
+
+        /* then */
+        assertThat(code).isBetween(100000, 1000000);
+    }
+}


### PR DESCRIPTION
## 👻 작업 요약

인증 메일 API를 구현하였습니다.

## ⚒️ 작업 내용

* 인증 메일 발송 API
* 인증 코드 확인 API

## 🎸 기타

Gmail 구현체를 완성해야 하며 회원 가입과 연동해야합니다. #53 

또, 인증 메일 전송 어뷰저에 대한 대책도 필요합니다. #54 

* closes #40
