### PR TITLE
feat: 사용자가 속한 팀들 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/github/teamreflog/reflogserver/team/application/TeamService.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/application/TeamService.java
@@ -40,6 +40,16 @@ public class TeamService {
                 .orElseThrow(ReflogIllegalArgumentException::new);
     }
 
+    @Transactional(readOnly = true)
+    public List<TeamQueryResponse> queryTeams(final Long memberId) {
+        final List<Long> teamIds =
+                crewRepository.findAllByMemberId(memberId).stream().map(Crew::getTeamId).toList();
+
+        return teamRepository.findAllByIdIn(teamIds).stream()
+                .map(TeamQueryResponse::fromEntity)
+                .toList();
+    }
+
     public List<CrewQueryResponse> queryCrews(final Long teamId) {
         final Team team =
                 teamRepository.findById(teamId).orElseThrow(ReflogIllegalArgumentException::new);

--- a/src/main/java/com/github/teamreflog/reflogserver/team/application/dto/TeamQueryResponse.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/application/dto/TeamQueryResponse.java
@@ -5,7 +5,7 @@ import java.time.DayOfWeek;
 import java.util.List;
 
 public record TeamQueryResponse(
-        Long id, String name, String description, Long ownerId, List<DayOfWeek> daysOfWeek) {
+        Long id, String name, String description, Long ownerId, List<DayOfWeek> reflectionDays) {
 
     public static TeamQueryResponse fromEntity(final Team team) {
         return new TeamQueryResponse(

--- a/src/main/java/com/github/teamreflog/reflogserver/team/domain/TeamRepository.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/domain/TeamRepository.java
@@ -1,5 +1,6 @@
 package com.github.teamreflog.reflogserver.team.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
@@ -10,4 +11,6 @@ public interface TeamRepository extends Repository<Team, Long> {
     boolean existsByName(String name);
 
     Optional<Team> findById(Long teamId);
+
+    List<Team> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/team/ui/TeamController.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/ui/TeamController.java
@@ -43,6 +43,12 @@ public class TeamController {
     }
 
     @Authorities(MemberRole.MEMBER)
+    @GetMapping
+    public List<TeamQueryResponse> queryTeams(@Authenticated final AuthPrincipal authPrincipal) {
+        return teamService.queryTeams(authPrincipal.memberId());
+    }
+
+    @Authorities(MemberRole.MEMBER)
     @GetMapping("/{id}/members")
     public List<CrewQueryResponse> queryCrews(@PathVariable("id") final Long teamId) {
         return teamService.queryCrews(teamId);

--- a/src/main/java/com/github/teamreflog/reflogserver/topic/infrastructure/TeamClient.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/topic/infrastructure/TeamClient.java
@@ -17,6 +17,6 @@ public class TeamClient implements TeamQueryClient {
     public TeamData getTeamData(final Long teamId) {
         final TeamQueryResponse response = teamService.queryTeam(teamId);
 
-        return new TeamData(response.id(), response.ownerId(), response.daysOfWeek());
+        return new TeamData(response.id(), response.ownerId(), response.reflectionDays());
     }
 }

--- a/src/test/java/com/github/teamreflog/reflogserver/acceptance/TeamAcceptanceTest.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/acceptance/TeamAcceptanceTest.java
@@ -86,7 +86,9 @@ class TeamAcceptanceTest extends AcceptanceTest {
                 .body("name", equalTo("antifragile"))
                 .body("description", equalTo("안티프래질 팀입니다."))
                 .body("ownerId", equalTo(memberId.intValue()))
-                .body("daysOfWeek", equalTo(List.of("MONDAY", "WEDNESDAY", "FRIDAY", "SUNDAY")));
+                .body(
+                        "reflectionDays",
+                        equalTo(List.of("MONDAY", "WEDNESDAY", "FRIDAY", "SUNDAY")));
     }
 
     @Test
@@ -131,13 +133,13 @@ class TeamAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.get(0).description()).isEqualTo("안티 팀입니다."),
                 () -> assertThat(response.get(0).ownerId()).isEqualTo(memberId),
                 () ->
-                        assertThat(response.get(0).daysOfWeek())
+                        assertThat(response.get(0).reflectionDays())
                                 .containsExactly(DayOfWeek.MONDAY, DayOfWeek.SUNDAY),
                 () -> assertThat(response.get(1).name()).isEqualTo("fragile"),
                 () -> assertThat(response.get(1).description()).isEqualTo("프래질 팀입니다."),
                 () -> assertThat(response.get(1).ownerId()).isEqualTo(memberId),
                 () ->
-                        assertThat(response.get(1).daysOfWeek())
+                        assertThat(response.get(1).reflectionDays())
                                 .containsExactly(DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY));
     }
 


### PR DESCRIPTION
## 👻 작업 요약

사용자가 속한 팀을 모두 조회하는 기능을 추가하였습니다.

## ⚒️ 작업 내용

* 사용자가 속한 모든 팀을 조회하는 API 추가 `GET /teams`
* ⚠️ 회고일 응답 필드명 변경 `dayOfWeeks` -> `reflectionDays`

## 🎸 기타

> [!IMPORTANT]
>
> Team 엔티티의 필드가 reflectionDays라서 응답 필드도 이에 맞게 변경하였습니다. 

* closes #55
