### PR TITLE
fix: 인터셉터가 CORS preflight 처리를 가장 먼저하도록 변경

### DIFF
--- a/src/main/java/com/github/teamreflog/reflogserver/auth/config/AuthInterceptor.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/auth/config/AuthInterceptor.java
@@ -30,15 +30,15 @@ public class AuthInterceptor implements HandlerInterceptor {
             final HttpServletResponse response,
             final Object handler)
             throws Exception {
-        final HandlerMethod handlerMethod = (HandlerMethod) handler;
-        final Authorities authorities = handlerMethod.getMethodAnnotation(Authorities.class);
-        if (authorities == null) {
-            return true;
-        }
-
         /* CORS preflight */
         if (OPTIONS.matches(request.getMethod())) {
             response.setStatus(HttpServletResponse.SC_ACCEPTED);
+            return true;
+        }
+
+        final HandlerMethod handlerMethod = (HandlerMethod) handler;
+        final Authorities authorities = handlerMethod.getMethodAnnotation(Authorities.class);
+        if (authorities == null) {
             return true;
         }
 


### PR DESCRIPTION
## 👻 작업 요약

인증 인가 인터셉터가 CORS preflight 처리를 최우선으로 하도록 변경하였습니다.

## ⚒️ 작업 내용

* CORS preflight 처리 순서 변경

## 🎸 기타

* closes #57