### PR TITLE
feat: 팀 상세 조회 API 추가

### DIFF
--- a/src/main/java/com/github/teamreflog/reflogserver/team/application/TeamService.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/application/TeamService.java
@@ -3,12 +3,16 @@ package com.github.teamreflog.reflogserver.team.application;
 import com.github.teamreflog.reflogserver.common.exception.ReflogIllegalArgumentException;
 import com.github.teamreflog.reflogserver.team.application.dto.CrewQueryResponse;
 import com.github.teamreflog.reflogserver.team.application.dto.TeamCreateRequest;
+import com.github.teamreflog.reflogserver.team.application.dto.TeamQueryDetailRequest;
+import com.github.teamreflog.reflogserver.team.application.dto.TeamQueryDetailResponse;
 import com.github.teamreflog.reflogserver.team.application.dto.TeamQueryResponse;
 import com.github.teamreflog.reflogserver.team.domain.Crew;
 import com.github.teamreflog.reflogserver.team.domain.CrewRepository;
 import com.github.teamreflog.reflogserver.team.domain.Team;
 import com.github.teamreflog.reflogserver.team.domain.TeamRepository;
 import com.github.teamreflog.reflogserver.team.domain.TeamValidator;
+import com.github.teamreflog.reflogserver.team.domain.TopicData;
+import com.github.teamreflog.reflogserver.team.domain.TopicQueryService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +26,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final CrewRepository crewRepository;
     private final TeamValidator teamValidator;
+    private final TopicQueryService topicQueryService;
 
     @Transactional
     public Long createTeam(final TeamCreateRequest request) {
@@ -57,5 +62,22 @@ public class TeamService {
         return crewRepository.findAllByTeamId(teamId).stream()
                 .map(crew -> CrewQueryResponse.fromEntity(crew, team))
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public TeamQueryDetailResponse queryTeamDetails(final TeamQueryDetailRequest request) {
+        if (crewRepository.findAllByTeamId(request.teamId()).stream()
+                .noneMatch(crew -> crew.isSameMemberId(request.memberId()))) {
+            throw new ReflogIllegalArgumentException();
+        }
+
+        final Team team =
+                teamRepository
+                        .findById(request.teamId())
+                        .orElseThrow(ReflogIllegalArgumentException::new);
+        final List<TopicData> topicData =
+                topicQueryService.getAllTopicDataByTeamId(request.teamId());
+
+        return TeamQueryDetailResponse.from(team, topicData);
     }
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/team/application/TeamService.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/application/TeamService.java
@@ -66,8 +66,8 @@ public class TeamService {
 
     @Transactional(readOnly = true)
     public TeamQueryDetailResponse queryTeamDetails(final TeamQueryDetailRequest request) {
-        if (crewRepository.findAllByTeamId(request.teamId()).stream()
-                .noneMatch(crew -> crew.isSameMemberId(request.memberId()))) {
+        final List<Crew> crews = crewRepository.findAllByTeamId(request.teamId());
+        if (crews.stream().noneMatch(crew -> crew.isSameMemberId(request.memberId()))) {
             throw new ReflogIllegalArgumentException();
         }
 
@@ -78,6 +78,6 @@ public class TeamService {
         final List<TopicData> topicData =
                 topicQueryService.getAllTopicDataByTeamId(request.teamId());
 
-        return TeamQueryDetailResponse.from(team, topicData);
+        return TeamQueryDetailResponse.from(team, crews, topicData);
     }
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/team/application/dto/TeamQueryDetailRequest.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/application/dto/TeamQueryDetailRequest.java
@@ -1,0 +1,3 @@
+package com.github.teamreflog.reflogserver.team.application.dto;
+
+public record TeamQueryDetailRequest(Long memberId, Long teamId) {}

--- a/src/main/java/com/github/teamreflog/reflogserver/team/application/dto/TeamQueryDetailResponse.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/application/dto/TeamQueryDetailResponse.java
@@ -1,0 +1,24 @@
+package com.github.teamreflog.reflogserver.team.application.dto;
+
+import com.github.teamreflog.reflogserver.team.domain.Team;
+import com.github.teamreflog.reflogserver.team.domain.TopicData;
+import java.time.DayOfWeek;
+import java.util.List;
+
+public record TeamQueryDetailResponse(
+        String name,
+        String description,
+        Long ownerId,
+        List<DayOfWeek> reflectionDays,
+        List<TopicData> topics) {
+
+    public static TeamQueryDetailResponse from(final Team team, final List<TopicData> topicData) {
+
+        return new TeamQueryDetailResponse(
+                team.getName(),
+                team.getDescription(),
+                team.getOwnerId(),
+                team.getReflectionDays(),
+                topicData);
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/team/application/dto/TeamQueryDetailResponse.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/application/dto/TeamQueryDetailResponse.java
@@ -1,5 +1,6 @@
 package com.github.teamreflog.reflogserver.team.application.dto;
 
+import com.github.teamreflog.reflogserver.team.domain.Crew;
 import com.github.teamreflog.reflogserver.team.domain.Team;
 import com.github.teamreflog.reflogserver.team.domain.TopicData;
 import java.time.DayOfWeek;
@@ -10,15 +11,18 @@ public record TeamQueryDetailResponse(
         String description,
         Long ownerId,
         List<DayOfWeek> reflectionDays,
+        List<CrewQueryResponse> crews,
         List<TopicData> topics) {
 
-    public static TeamQueryDetailResponse from(final Team team, final List<TopicData> topicData) {
+    public static TeamQueryDetailResponse from(
+            final Team team, final List<Crew> crews, final List<TopicData> topicData) {
 
         return new TeamQueryDetailResponse(
                 team.getName(),
                 team.getDescription(),
                 team.getOwnerId(),
                 team.getReflectionDays(),
+                crews.stream().map(crew -> CrewQueryResponse.fromEntity(crew, team)).toList(),
                 topicData);
     }
 }

--- a/src/main/java/com/github/teamreflog/reflogserver/team/domain/TopicData.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/domain/TopicData.java
@@ -1,0 +1,3 @@
+package com.github.teamreflog.reflogserver.team.domain;
+
+public record TopicData(Long id, String content) {}

--- a/src/main/java/com/github/teamreflog/reflogserver/team/domain/TopicQueryService.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/domain/TopicQueryService.java
@@ -1,0 +1,8 @@
+package com.github.teamreflog.reflogserver.team.domain;
+
+import java.util.List;
+
+public interface TopicQueryService {
+
+    List<TopicData> getAllTopicDataByTeamId(Long teamId);
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/team/infrastructure/TopicClient.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/infrastructure/TopicClient.java
@@ -1,0 +1,22 @@
+package com.github.teamreflog.reflogserver.team.infrastructure;
+
+import com.github.teamreflog.reflogserver.team.domain.TopicData;
+import com.github.teamreflog.reflogserver.team.domain.TopicQueryService;
+import com.github.teamreflog.reflogserver.topic.domain.TopicRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TopicClient implements TopicQueryService {
+
+    private final TopicRepository topicRepository;
+
+    @Override
+    public List<TopicData> getAllTopicDataByTeamId(final Long teamId) {
+        return topicRepository.findAllByTeamId(teamId).stream()
+                .map(topic -> new TopicData(topic.getId(), topic.getContent()))
+                .toList();
+    }
+}

--- a/src/main/java/com/github/teamreflog/reflogserver/team/ui/TeamController.java
+++ b/src/main/java/com/github/teamreflog/reflogserver/team/ui/TeamController.java
@@ -7,6 +7,8 @@ import com.github.teamreflog.reflogserver.auth.domain.MemberRole;
 import com.github.teamreflog.reflogserver.team.application.TeamService;
 import com.github.teamreflog.reflogserver.team.application.dto.CrewQueryResponse;
 import com.github.teamreflog.reflogserver.team.application.dto.TeamCreateRequest;
+import com.github.teamreflog.reflogserver.team.application.dto.TeamQueryDetailRequest;
+import com.github.teamreflog.reflogserver.team.application.dto.TeamQueryDetailResponse;
 import com.github.teamreflog.reflogserver.team.application.dto.TeamQueryResponse;
 import java.net.URI;
 import java.util.List;
@@ -46,6 +48,15 @@ public class TeamController {
     @GetMapping
     public List<TeamQueryResponse> queryTeams(@Authenticated final AuthPrincipal authPrincipal) {
         return teamService.queryTeams(authPrincipal.memberId());
+    }
+
+    @Authorities(MemberRole.MEMBER)
+    @GetMapping("/{id}/detail")
+    public TeamQueryDetailResponse queryTeamDetails(
+            @Authenticated final AuthPrincipal authPrincipal,
+            @PathVariable("id") final Long teamId) {
+        return teamService.queryTeamDetails(
+                new TeamQueryDetailRequest(authPrincipal.memberId(), teamId));
     }
 
     @Authorities(MemberRole.MEMBER)

--- a/src/test/java/com/github/teamreflog/reflogserver/acceptance/TeamAcceptanceTest.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/acceptance/TeamAcceptanceTest.java
@@ -185,6 +185,11 @@ class TeamAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.name()).isEqualTo("antifragile"),
                 () -> assertThat(response.description()).isEqualTo("안티프래질 팀입니다."),
                 () -> assertThat(response.ownerId()).isNotNull(),
+                () -> assertThat(response.crews()).hasSize(1),
+                () -> assertThat(response.crews().get(0).nickname()).isEqualTo("owner"),
+                () -> assertThat(response.crews().get(0).memberId()).isEqualTo(response.ownerId()),
+                () -> assertThat(response.crews().get(0).isOwner()).isTrue(),
+                () -> assertThat(response.crews().get(0).joinedAt()).isNotNull(),
                 () ->
                         assertThat(response.reflectionDays())
                                 .containsExactly(

--- a/src/test/java/com/github/teamreflog/reflogserver/acceptance/TeamAcceptanceTest.java
+++ b/src/test/java/com/github/teamreflog/reflogserver/acceptance/TeamAcceptanceTest.java
@@ -9,9 +9,11 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import com.github.teamreflog.reflogserver.acceptance.fixture.AuthFixture;
 import com.github.teamreflog.reflogserver.acceptance.fixture.MemberFixture;
 import com.github.teamreflog.reflogserver.acceptance.fixture.TeamFixture;
+import com.github.teamreflog.reflogserver.acceptance.fixture.TopicFixture;
 import com.github.teamreflog.reflogserver.auth.application.dto.TokenResponse;
 import com.github.teamreflog.reflogserver.team.application.dto.CrewQueryResponse;
 import com.github.teamreflog.reflogserver.team.application.dto.TeamCreateRequest;
+import com.github.teamreflog.reflogserver.team.application.dto.TeamQueryDetailResponse;
 import com.github.teamreflog.reflogserver.team.application.dto.TeamQueryResponse;
 import io.restassured.RestAssured;
 import java.time.DayOfWeek;
@@ -141,6 +143,58 @@ class TeamAcceptanceTest extends AcceptanceTest {
                 () ->
                         assertThat(response.get(1).reflectionDays())
                                 .containsExactly(DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY));
+    }
+
+    @Test
+    @DisplayName("팀 상세 정보를 조회할 수 있다.")
+    void queryTeamDetail() {
+        MemberFixture.createMember("owner@email.com", "owner");
+        final String ownerAccessToken = AuthFixture.login("owner@email.com", "owner").accessToken();
+        final Long teamId =
+                TeamFixture.createTeam(
+                        ownerAccessToken,
+                        "antifragile",
+                        "안티프래질 팀입니다.",
+                        "owner",
+                        List.of(
+                                DayOfWeek.MONDAY,
+                                DayOfWeek.WEDNESDAY,
+                                DayOfWeek.FRIDAY,
+                                DayOfWeek.SUNDAY));
+        TopicFixture.createTopic(ownerAccessToken, teamId, "오늘 하루는 어땠나요?");
+        TopicFixture.createTopic(ownerAccessToken, teamId, "오늘은 어떤 것을 먹었나요?");
+
+        /* when */
+        final TeamQueryDetailResponse response =
+                RestAssured.given()
+                        .log()
+                        .all()
+                        .auth()
+                        .oauth2(ownerAccessToken)
+                        .when()
+                        .get("/teams/{teamId}/detail", teamId)
+                        .then()
+                        .log()
+                        .all()
+                        .statusCode(200)
+                        .extract()
+                        .as(TeamQueryDetailResponse.class);
+
+        /* then */
+        assertAll(
+                () -> assertThat(response.name()).isEqualTo("antifragile"),
+                () -> assertThat(response.description()).isEqualTo("안티프래질 팀입니다."),
+                () -> assertThat(response.ownerId()).isNotNull(),
+                () ->
+                        assertThat(response.reflectionDays())
+                                .containsExactly(
+                                        DayOfWeek.MONDAY,
+                                        DayOfWeek.WEDNESDAY,
+                                        DayOfWeek.FRIDAY,
+                                        DayOfWeek.SUNDAY),
+                () -> assertThat(response.topics()).hasSize(2),
+                () -> assertThat(response.topics().get(0).content()).isEqualTo("오늘 하루는 어땠나요?"),
+                () -> assertThat(response.topics().get(1).content()).isEqualTo("오늘은 어떤 것을 먹었나요?"));
     }
 
     @Test


### PR DESCRIPTION
## 👻 작업 요약

팀 정보와 팀원, 회고를 동시에 조회하는 팀 상세 정보 API를 구현하였습니다.

## ⚒️ 작업 내용

* 팀 상세 정보 API 구현

## 🎸 기타